### PR TITLE
2-local dev

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,5 +12,6 @@ LazyData: true
 Imports:
     magrittr,
     ssh,
-    sys
+    sys,
+    fs
 RoxygenNote: 6.1.1

--- a/R/neo4j_import.R
+++ b/R/neo4j_import.R
@@ -3,6 +3,7 @@
 #' @param con List containing three objects: bolt address, uid, pwd as character strings providing connection to the Neo4J server
 #' @param source Character string of local path to the csv, zip or tar.gz compressed csv file
 #' @param import_dir Character string of path to the import directory on the Neo4J server for ssh file transfer and unzipping
+#' @param local_dev Logical to determine if usage is on remote server (FALSE, default) or if server is on local machine (TRUE)
 #' @param gunzip_path Path to gunzip to be passed to the system command on the Neo4J server
 #' @param tar_path Path to tar to be passed to the system command on the Neo4J server
 #' @param unzip_path Path to unzip to be passed to the system command on the Neo4J server
@@ -11,35 +12,42 @@
 
 
 neo4j_import <- function (con = list(address = NULL, uid = NULL, pwd = NULL), source = NULL,
-                          import_dir = NULL, unzip_path = "unzip",
+                          import_dir = NULL, local_dev = FALSE, unzip_path = "unzip",
                           gunzip_path = "gunzip", tar_path = "tar") {
 
   if (substr(import_dir, nchar(import_dir), nchar(import_dir)) != "/") {
     import_dir <- paste0(import_dir, "/")
   }
-
-
-  ssh_uid <- paste0(con$uid, "@", basename(con$address))
-
-  if (substr(source, nchar(source) - 3, nchar(source)) == ".csv") {
-    session <- ssh::ssh_connect(ssh_uid, passwd = con$pwd)
-    ssh::scp_upload(session, source, to = import_dir)
-    ssh::ssh_disconnect(session)
-  } else if (substr(source, nchar(source) - 3, nchar(source)) == ".zip") {
-    session <- ssh::ssh_connect(ssh_uid, passwd = con$pwd)
-    ssh::scp_upload(session, source, to = import_dir)
-    ssh::ssh_exec_wait(session, paste(unzip_path, paste0(import_dir, basename(source)), "-d", import_dir))
-    ssh::ssh_exec_wait(session, paste("rm", paste0(import_dir, basename(source))))
-    ssh::ssh_disconnect(session)
-  } else if (substr(source, nchar(source) - 6, nchar(source)) == ".tar.gz") {
-    session <- ssh::ssh_connect(ssh_uid, passwd = con$pwd)
-    ssh::scp_upload(session, source, to = import_dir)
-    ssh::ssh_exec_wait(session, paste(gunzip_path, "-f", paste0(import_dir, basename(source))))
-    ssh::ssh_exec_wait(session, paste(tar_path, "-C", import_dir, "-xvf", paste0(import_dir, gsub(".gz", "", basename(source)))))
-    ssh::ssh_exec_wait(session, paste("rm", paste0(import_dir, gsub(".gz", "", basename(source)))))
-    ssh::ssh_disconnect(session)
+  
+  # for local dev:  TODO: more checks as below for filetype
+  if (local_dev) {
+    if(is.null(source)) {
+      stop("Source must be specified.")
+    }
+    fs::file_move(source, import_dir)
   } else {
-    stop("Source is not a .csv, .zip or a .tar.gz file.")
+    ssh_uid <- paste0(con$uid, "@", basename(con$address))
+    
+    if (substr(source, nchar(source) - 3, nchar(source)) == ".csv") {
+      session <- ssh::ssh_connect(ssh_uid, passwd = con$pwd)
+      ssh::scp_upload(session, source, to = import_dir)
+      ssh::ssh_disconnect(session)
+    } else if (substr(source, nchar(source) - 3, nchar(source)) == ".zip") {
+      session <- ssh::ssh_connect(ssh_uid, passwd = con$pwd)
+      ssh::scp_upload(session, source, to = import_dir)
+      ssh::ssh_exec_wait(session, paste(unzip_path, paste0(import_dir, basename(source)), "-d", import_dir))
+      ssh::ssh_exec_wait(session, paste("rm", paste0(import_dir, basename(source))))
+      ssh::ssh_disconnect(session)
+    } else if (substr(source, nchar(source) - 6, nchar(source)) == ".tar.gz") {
+      session <- ssh::ssh_connect(ssh_uid, passwd = con$pwd)
+      ssh::scp_upload(session, source, to = import_dir)
+      ssh::ssh_exec_wait(session, paste(gunzip_path, "-f", paste0(import_dir, basename(source))))
+      ssh::ssh_exec_wait(session, paste(tar_path, "-C", import_dir, "-xvf", paste0(import_dir, gsub(".gz", "", basename(source)))))
+      ssh::ssh_exec_wait(session, paste("rm", paste0(import_dir, gsub(".gz", "", basename(source)))))
+      ssh::ssh_disconnect(session)
+    } else {
+      stop("Source is not a .csv, .zip or a .tar.gz file.")
+    }
   }
 }
 

--- a/R/neo4j_rmdir.R
+++ b/R/neo4j_rmdir.R
@@ -3,11 +3,12 @@
 #' @param con List containing three objects: bolt address, uid, pwd as character strings providing connection to the Neo4J server
 #' @param dir Character string of the import subdirectory name to be deleted on the Neo4J server
 #' @param import_dir Character string of path to the import directory on the Neo4J server
+#' @param local_dev Logical to determine if usage is on remote server (FALSE, default) or if server is on local machine (TRUE)
 #'
 #' @return A success message if successful.  A text string if an error is encountered.
 
 
-neo4j_rmdir <- function (con = list(address = NULL, uid = NULL, pwd = NULL), dir = NULL, import_dir = NULL) {
+neo4j_rmdir <- function (con = list(address = NULL, uid = NULL, pwd = NULL), dir = NULL, import_dir = NULL, local_dev = FALSE) {
 
   if (substr(import_dir, nchar(import_dir), nchar(import_dir)) != "/") {
     import_dir <- paste0(import_dir, "/")
@@ -15,17 +16,23 @@ neo4j_rmdir <- function (con = list(address = NULL, uid = NULL, pwd = NULL), dir
 
   filestring <- paste0(import_dir, dir)
   tmp1 <- tempfile()
-
-  ssh_uid <- paste0(con$uid, "@", basename(con$address))
-  session <- ssh::ssh_connect(ssh_uid, passwd = con$pwd)
-  output <- ssh::ssh_exec_wait(session, command = paste("rm -r", filestring), std_err = tmp1)
-  ssh::ssh_disconnect(session)
-
-  if (output == 0) {
-    message("Directory and all contents removed successfuly!")
+  
+  if (local_dev) {
+    fs::dir_delete(filestring)
+    if (!fs::dir_exists(filestring)) {
+      message("Directory and all contents removed successfuly!")
+    }
   } else {
-    readLines(tmp1) %>% paste(collapse = " ") %>% noquote() %>% warning(call. = FALSE)
+    ssh_uid <- paste0(con$uid, "@", basename(con$address))
+    session <- ssh::ssh_connect(ssh_uid, passwd = con$pwd)
+    output <- ssh::ssh_exec_wait(session, command = paste("rm -r", filestring), std_err = tmp1)
+    ssh::ssh_disconnect(session)
+    
+    if (output == 0) {
+      message("Directory and all contents removed successfuly!")
+    } else {
+      readLines(tmp1) %>% paste(collapse = " ") %>% noquote() %>% warning(call. = FALSE)
+    }
   }
-
 }
 


### PR DESCRIPTION
As a user that often works locally to prototype and personal research projects, the other features of this library would not work as there is an assumption that the management of the server is only on a remote machine.

This PR adds a flag `local_dev`,  which is `FALSE` by default.  If `TRUE`, the actions are taken on the local machine. 

This package also adds a dependency to the `fs` package to make the management of files and directories easier to handle over Base R.

## Test Code

```
options(stringsAsFactors=FALSE)

## load the packages
library(neo4jshell)

## graph setup
graph = list(address = "bolt://localhost:7687", uid = "neo4j", pwd = "password")
SHELL_LOC = "/Users/btibert/neo4j-community-3.5.8/bin/cypher-shell"
IMPORT_LOC = "/Users/btibert/neo4j-community-3.5.8/import/"

## wakefield - generate a simple dataset
install.packages("wakefield")
library(wakefield)
df = r_data_frame(100, 
                  id, 
                  age,
                  gender)
readr::write_csv(df, "test-df.csv")
# > list.files(pattern = "test")
# [1] "test-df.csv"
neo4j_import(graph, source="test-df.csv", import_dir = IMPORT_LOC, local_dev = TRUE)


## remove the file
neo4j_rmfiles(graph, files="test-df.csv", import_dir = IMPORT_LOC, local_dev = TRUE)

## create a test subdirectory
fs::dir_create(paste0(IMPORT_LOC, "test-dr"))
fs::dir_ls(IMPORT_LOC)
neo4j_rmdir(graph, dir = "test-dr", import_dir = IMPORT_LOC, local_dev = TRUE)
fs::dir_ls(IMPORT_LOC)
```